### PR TITLE
fix ordering of content fields in example data

### DIFF
--- a/drafts/draft-ssb-core-gabbygrove/00/draft-ssb-core-gabbygrove-00.html
+++ b/drafts/draft-ssb-core-gabbygrove/00/draft-ssb-core-gabbygrove-00.html
@@ -414,7 +414,7 @@
 
   <meta name="dct.creator" content="cryptix, ." />
   <meta name="dct.identifier" content="urn:ietf:id:draft-ssb-core-gabbygrove-00" />
-  <meta name="dct.issued" scheme="ISO8601" content="2019-08-16" />
+  <meta name="dct.issued" scheme="ISO8601" content="2019-09-09" />
   <meta name="dct.abstract" content="This document defines a new binary format for append-only feeds as used by Secure-Scuttlebutt.  That is, it defines the bytes that are used for computing the cryptographic signatures and hashes that make up a feed in this format.  It strives to do two things: Be easier to implement compared to the current scheme. Hence, it uses CBOR  to encode the logical values that describe each entry.  Secondly, the feed entry only references content by hash to enable content deletion without breaking verification of the feed." />
   <meta name="description" content="This document defines a new binary format for append-only feeds as used by Secure-Scuttlebutt.  That is, it defines the bytes that are used for computing the cryptographic signatures and hashes that make up a feed in this format.  It strives to do two things: Be easier to implement compared to the current scheme. Hence, it uses CBOR  to encode the logical values that describe each entry.  Secondly, the feed entry only references content by hash to enable content deletion without breaking verification of the feed." />
 
@@ -435,10 +435,10 @@
 </tr>
 <tr>
 <td class="left">Intended status: Informational</td>
-<td class="right">August 16, 2019</td>
+<td class="right">September 09, 2019</td>
 </tr>
 <tr>
-<td class="left">Expires: February 17, 2020</td>
+<td class="left">Expires: March 12, 2020</td>
 <td class="right"></td>
 </tr>
 
@@ -454,7 +454,7 @@
 <h1 id="rfc.status"><a href="#rfc.status">Status of This Memo</a></h1>
 <p>SSB-Drafts are working documents of the Secure Scuttlebutt community.  Note that other groups may also distribute working documents as SSB-Drafts.</p>
 <p>SSB-Drafts are draft documents valid for a maximum of six months and may be updated, replaced, or obsoleted by other documents at any time.  It is inappropriate to use SSB-Drafts as reference material or to cite them other than as "work in progress."</p>
-<p>This SSB-Draft will expire on February 17, 2020.</p>
+<p>This SSB-Draft will expire on March 12, 2020.</p>
 <h1 id="rfc.copyrightnotice"><a href="#rfc.copyrightnotice">Copyright Notice</a></h1>
 <p>Copyright (c) 2019 SSB Council and the persons identified as the document authors.  All rights reserved.</p>
 
@@ -717,15 +717,15 @@ A4               # map(4)
  6:         AED3DAB65CE9E0D6C50D46FCEFFB5522
  7:         96ED21B6E0B537A6A0184575CE8F5CBD
  8:   01                                   # unsigned(1)
- 9:   1A 5D3F8880                          # unsigned(1564444800)
+ 9:   24                                   # negative(4)
 10:   83                                   # array(3)
-11:      01                                # unsigned(1)
-12:      07                                # unsigned(7)
-13:      D9 041A                           # tag(1050)
-14:         58 21                          # bytes(33)
-15:            03
-16:            E806ECF2B7C37FB06DC198A9B905BE64
-17:            EE3FDB8237EF80D316ACB7C85BBF5F02
+11:      D9 041A                           # tag(1050)
+12:         58 21                          # bytes(33)
+13:            03
+14:            A7AC59B52AFF894BA89508B35F445AE9
+15:            0628F6D5F358157E4F45F39B5B3BE96B
+16:      09                                # unsigned(9)
+17:      00                                # unsigned(0)
 </pre>
 <p id="rfc.section.4.4.2.p.2">Let&#8217;s discuss line by line what this means:</p>
 <p></p>
@@ -740,14 +740,13 @@ A4               # map(4)
 <li>This is the first half of the authors public key, broken in two lines of 16bytes each. (This is only to conform with the 72 character limit of text only output of this document.)</li>
 <li>This is the 2nd half of the authors public key.</li>
 <li>The next line is the third element of the array: the <samp>sequence</samp> number encoded as an unsigned integer, as the comment tells us.</li>
-<li>The fourth element is the <samp>timestamp</samp> also encoded as an unsigned integer. As a starting timestamp I picked 2019-07-30, which translates to 1564444800 seconds as a Unix epoch timestamp.</li>
-<li>The fifth element is the <samp>content</samp> object, which itself is encoded as an array of 3 items (<samp>encoding</samp>, <samp>size</samp> and <samp>hash</samp>)</li>
-<li>The number 1 means the content was encoded as <samp>json</samp> (See Section 2.3).</li>
-<li>This is the content&#8217;s <samp>size</samp>, in bytes also as an unsigned integer. Meaning, this content is 7 bytes long.</li>
-<li>Finally, we have a cipherlink again.</li>
-<li>It&#8217;s 33 bytes long</li>
+<li>The fourth element is the <samp>timestamp</samp> encoded as an signed integer. As a starting timestamp I picked 1969-12-31 23:59:55, which translates to -5 seconds as a UNIX epoch timestamp.</li>
+<li>The fifth element is the <samp>content</samp> object, which itself is encoded as an array of 3 items (<samp>hash</samp>, <samp>size</samp> and <samp>encoding</samp>)</li>
+<li>First, we have a cipherlink for the <samp>hash</samp>.</li>
 <li>It starts with 03 which means, it&#8217;s a content hash. (See Section 3.3)</li>
-<li>The following two lines are the hash function output. Where this comes from will be shown in the next section.</li>
+<li>The following two lines are the hash function output. How to compute these will be shown in the next section.</li>
+<li>This is the content&#8217;s <samp>size</samp>, in bytes also as an unsigned integer. Meaning, this content is 9 bytes long.</li>
+<li>The number 0 means the content was encoded as <samp>binary</samp> (See Section 2.3).</li>
 </ol>
 <p id="rfc.section.4.4.2.p.4">Here is the next message:</p>
 <pre>
@@ -755,61 +754,60 @@ A4               # map(4)
    D9 041A                              # tag(1050)
       58 21                             # bytes(33)
          02
-         0113F4DD8C981D1D87BC7F46CF86E8E7
-         B0FB774F839930DD38D6A13F69D9693D
+         CCD8FD8392C1B9D1E3026DEA42BEC93E
+         04B6F8ECEB9AF2D591489EB8B831C5E1
    D9 041A                              # tag(1050)
       58 21                             # bytes(33)
          01
          AED3DAB65CE9E0D6C50D46FCEFFB5522
          96ED21B6E0B537A6A0184575CE8F5CBD
    02                                   # unsigned(2)
-   1A 5D3F8881                          # unsigned(1564444801)
+   23                                   # negative(3)
    83                                   # array(3)
-      01                                # unsigned(1)
-      16                                # unsigned(22)
       D9 041A                           # tag(1050)
          58 21                          # bytes(33)
             03
             95CCA4FA7B24ABC6049683E716292B00
             C49509BE147AA024C06286BD9B7DBDA8
+      16                                # unsigned(22)
+      01                                # unsigned(1)
 
 </pre>
-<p id="rfc.section.4.4.2.p.5">If you compare this to the above you should see some similarities. Instead of <samp>0xf6</samp> as the first element as the array we now have <samp>0xD0491A5821</samp>. We have seen this sequence twice above already: It&#8217;s a cipherlink with 33 bytes of data. Instead of starting with byte <samp>0x01</samp> or <samp>0x03</samp>, this starts with <samp>0x02</samp> which means, it&#8217;s a hash of a signed event.</p>
+<p id="rfc.section.4.4.2.p.5">If you compare this to the above you should see some similarities. Instead of <samp>0xf6</samp> as the first element as the array we now have <samp>0xD9041A5821</samp>. We have seen this sequence of bytes twice above already: It&#8217;s a cipherlink with 33 bytes of data. Instead of starting with byte <samp>0x01</samp> or <samp>0x03</samp>, this starts with <samp>0x02</samp> which means, it&#8217;s a hash of a signed event.</p>
+<p id="rfc.section.4.4.2.p.6">The content type is <samp>0x01</samp> instead and the timestamp is advanced by 1 as well as the <samp>sequence</samp>.</p>
 <h1 id="rfc.section.4.4.3">
 <a href="#rfc.section.4.4.3">4.4.3.</a> <a href="#transfer-1" id="transfer-1">Transfer</a>
 </h1>
 <p id="rfc.section.4.4.3.p.1">Here is the transfer object for the first event:</p>
 <pre>
 83                                      # array(3)
-   58 57                                # bytes(87)
+   58 53                                # bytes(83)
       85F6D9041A582101AED3DAB65CE9E0D6C50D46FCEFFB552296ED21B6E
-      0B537A6A0184575CE8F5CBD011A5D3F8880830107D9041A582103E806
-      ECF2B7C37FB06DC198A9B905BE64EE3FDB8237EF80D316ACB7C85BBF5
-      F02
+      0B537A6A0184575CE8F5CBD012483D9041A582103A7AC59B52AFF894B
+      A89508B35F445AE90628F6D5F358157E4F45F39B5B3BE96B0900
    58 40                                # bytes(64)
-      91F1B00C37285FC517D4C87FDA951A6BC38AEE7E7DCB8E3CE538289C5
-      CBA0E93A5734BD6853D11FA29DDF0BFE5BC4B5049EF4681CAA1BAA355
-      CD2FFC94191104
-   47                                   # bytes(7)
-      666F6F2E626F78                    # "foo.box"
+      8A3739FDB99D91E28552E9A2E22650C14A8CDBFE607CDCA5767569DB2
+      B1E24CAA3C31D65964143DC752E568B05C99E0E97C198885BFB8F3549
+      B9C6CCBC991205
+   49                                   # bytes(9)
+      FF7330316D4279747A                # "\xFFs01mBytz"
 </pre>
 <p id="rfc.section.4.4.3.p.2">Similar to the above, we have an array with 3 elements, each in turn being a byte string of varying size.  The first one is the <samp>eventData</samp>, the second one is the <samp>signature</samp> and the last one is the <samp>content</samp> data.  (The long data chunks were broken into multiple lines for readability, consult the code repositories for actual test vectors.)</p>
 <p id="rfc.section.4.4.3.p.3">Here is the transfer object for the second event:</p>
 <pre>
 83                                      # array(3)
-   58 7C                                # bytes(124)
-      85D9041A5821020113F4DD8C981D1D87BC7F46CF86E8E7B0FB774F839
-      930DD38D6A13F69D9693DD9041A582101AED3DAB65CE9E0D6C50D46FC
-      EFFB552296ED21B6E0B537A6A0184575CE8F5CBD021A5D3F888183011
-      6D9041A58210395CCA4FA7B24ABC6049683E716292B00C49509BE147A
-      A024C06286BD9B7DBDA8
+   58 78                                # bytes(120)
+      85D9041A582102CCD8FD8392C1B9D1E3026DEA42BEC93E04B6F8ECEB9
+      AF2D591489EB8B831C5E1D9041A582101AED3DAB65CE9E0D6C50D46FC
+      EFFB552296ED21B6E0B537A6A0184575CE8F5CBD022383D9041A58210
+      395CCA4FA7B24ABC6049683E716292B00C49509BE147AA024C06286BD
+      9B7DBDA81601
    58 40                                # bytes(64)
-      AFE8658C6F5229951DB4DB82F62E9D930B6CD8F155C5D47586556012E
-      D9C560487C05AAE58A2B66970CBAB666E43890DEB01F33E5281B0F9C7
-      E22F68A437AF09
+      3A7F29F7395CC454C3904DE2236EEF2C0147496B77C556ADE1A08BF57
+      D3E70D2A43A4C723AEB5366D4F073CEEB8B2677E03EC62E49D1647C67
+      0D95CC77F9DB07
    56                                   # bytes(22)
       7B2269223A312C2274797065223A2274657374227D0A
-
 </pre>
 <h1 id="rfc.section.5">
 <a href="#rfc.section.5">5.</a> <a href="#code-and-roll-out" id="code-and-roll-out">Code and roll out</a>

--- a/drafts/draft-ssb-core-gabbygrove/00/draft-ssb-core-gabbygrove-00.md
+++ b/drafts/draft-ssb-core-gabbygrove/00/draft-ssb-core-gabbygrove-00.md
@@ -242,15 +242,15 @@ These are the first two messages of a feed authored by the keypair above.
  6:         AED3DAB65CE9E0D6C50D46FCEFFB5522
  7:         96ED21B6E0B537A6A0184575CE8F5CBD
  8:   01                                   # unsigned(1)
- 9:   1A 5D3F8880                          # unsigned(1564444800)
+ 9:   24                                   # negative(4)
 10:   83                                   # array(3)
-11:      01                                # unsigned(1)
-12:      07                                # unsigned(7)
-13:      D9 041A                           # tag(1050)
-14:         58 21                          # bytes(33)
-15:            03
-16:            E806ECF2B7C37FB06DC198A9B905BE64
-17:            EE3FDB8237EF80D316ACB7C85BBF5F02
+11:      D9 041A                           # tag(1050)
+12:         58 21                          # bytes(33)
+13:            03
+14:            A7AC59B52AFF894BA89508B35F445AE9
+15:            0628F6D5F358157E4F45F39B5B3BE96B
+16:      09                                # unsigned(9)
+17:      00                                # unsigned(0)
 ~~~~~~~~~~~
 
 Let's discuss line by line what this means:
@@ -263,14 +263,13 @@ Let's discuss line by line what this means:
 6. This is the first half of the authors public key, broken in two lines of 16bytes each. (This is only to conform with the 72 character limit of text only output of this document.)
 7. This is the 2nd half of the authors public key.
 8. The next line is the third element of the array: the `sequence` number encoded as an unsigned integer, as the comment tells us.
-9. The fourth element is the `timestamp` also encoded as an unsigned integer. As a starting timestamp I picked 2019-07-30, which translates to 1564444800 seconds as a Unix epoch timestamp.
-10. The fifth element is the `content` object, which itself is encoded as an array of 3 items (`encoding`, `size` and `hash`)
-11. The number 1 means the content was encoded as `json` (See Section 2.3).
-12. This is the content's `size`, in bytes also as an unsigned integer. Meaning, this content is 7 bytes long.
-13. Finally, we have a cipherlink again.
-14. It's 33 bytes long
-15. It starts with 03 which means, it's a content hash. (See Section 3.3)
-16. The following two lines are the hash function output. Where this comes from will be shown in the next section.
+9. The fourth element is the `timestamp` encoded as an signed integer. As a starting timestamp I picked 1969-12-31 23:59:55, which translates to -5 seconds as a UNIX epoch timestamp.
+10. The fifth element is the `content` object, which itself is encoded as an array of 3 items (`hash`, `size` and `encoding`)
+11. First, we have a cipherlink for the `hash`.
+13. It starts with 03 which means, it's a content hash. (See Section 3.3)
+14. The following two lines are the hash function output. How to compute these will be shown in the next section.
+16. This is the content's `size`, in bytes also as an unsigned integer. Meaning, this content is 9 bytes long.
+17. The number 0 means the content was encoded as `binary` (See Section 2.3).
 
 Here is the next message:
 
@@ -279,27 +278,29 @@ Here is the next message:
    D9 041A                              # tag(1050)
       58 21                             # bytes(33)
          02
-         0113F4DD8C981D1D87BC7F46CF86E8E7
-         B0FB774F839930DD38D6A13F69D9693D
+         CCD8FD8392C1B9D1E3026DEA42BEC93E
+         04B6F8ECEB9AF2D591489EB8B831C5E1
    D9 041A                              # tag(1050)
       58 21                             # bytes(33)
          01
          AED3DAB65CE9E0D6C50D46FCEFFB5522
          96ED21B6E0B537A6A0184575CE8F5CBD
    02                                   # unsigned(2)
-   1A 5D3F8881                          # unsigned(1564444801)
+   23                                   # negative(3)
    83                                   # array(3)
-      01                                # unsigned(1)
-      16                                # unsigned(22)
       D9 041A                           # tag(1050)
          58 21                          # bytes(33)
             03
             95CCA4FA7B24ABC6049683E716292B00
             C49509BE147AA024C06286BD9B7DBDA8
+      16                                # unsigned(22)
+      01                                # unsigned(1)
 
 ~~~~~~~~~~~
 
-If you compare this to the above you should see some similarities. Instead of `0xf6` as the first element as the array we now have `0xD0491A5821`. We have seen this sequence twice above already: It's a cipherlink with 33 bytes of data. Instead of starting with byte `0x01` or `0x03`, this starts with `0x02` which means, it's a hash of a signed event.
+If you compare this to the above you should see some similarities. Instead of `0xf6` as the first element as the array we now have `0xD9041A5821`. We have seen this sequence of bytes twice above already: It's a cipherlink with 33 bytes of data. Instead of starting with byte `0x01` or `0x03`, this starts with `0x02` which means, it's a hash of a signed event.
+
+The content type is `0x01` instead and the timestamp is advanced by 1 as well as the `sequence`.
 
 ### Transfer
 
@@ -307,17 +308,16 @@ Here is the transfer object for the first event:
 
 ~~~~~~~~~~~
 83                                      # array(3)
-   58 57                                # bytes(87)
+   58 53                                # bytes(83)
       85F6D9041A582101AED3DAB65CE9E0D6C50D46FCEFFB552296ED21B6E
-      0B537A6A0184575CE8F5CBD011A5D3F8880830107D9041A582103E806
-      ECF2B7C37FB06DC198A9B905BE64EE3FDB8237EF80D316ACB7C85BBF5
-      F02
+      0B537A6A0184575CE8F5CBD012483D9041A582103A7AC59B52AFF894B
+      A89508B35F445AE90628F6D5F358157E4F45F39B5B3BE96B0900
    58 40                                # bytes(64)
-      91F1B00C37285FC517D4C87FDA951A6BC38AEE7E7DCB8E3CE538289C5
-      CBA0E93A5734BD6853D11FA29DDF0BFE5BC4B5049EF4681CAA1BAA355
-      CD2FFC94191104
-   47                                   # bytes(7)
-      666F6F2E626F78                    # "foo.box"
+      8A3739FDB99D91E28552E9A2E22650C14A8CDBFE607CDCA5767569DB2
+      B1E24CAA3C31D65964143DC752E568B05C99E0E97C198885BFB8F3549
+      B9C6CCBC991205
+   49                                   # bytes(9)
+      FF7330316D4279747A                # "\xFFs01mBytz"
 ~~~~~~~~~~~
 
 Similar to the above, we have an array with 3 elements, each in turn being a byte string of varying size.
@@ -329,21 +329,19 @@ Here is the transfer object for the second event:
 
 ~~~~~~~~~~~
 83                                      # array(3)
-   58 7C                                # bytes(124)
-      85D9041A5821020113F4DD8C981D1D87BC7F46CF86E8E7B0FB774F839
-      930DD38D6A13F69D9693DD9041A582101AED3DAB65CE9E0D6C50D46FC
-      EFFB552296ED21B6E0B537A6A0184575CE8F5CBD021A5D3F888183011
-      6D9041A58210395CCA4FA7B24ABC6049683E716292B00C49509BE147A
-      A024C06286BD9B7DBDA8
+   58 78                                # bytes(120)
+      85D9041A582102CCD8FD8392C1B9D1E3026DEA42BEC93E04B6F8ECEB9
+      AF2D591489EB8B831C5E1D9041A582101AED3DAB65CE9E0D6C50D46FC
+      EFFB552296ED21B6E0B537A6A0184575CE8F5CBD022383D9041A58210
+      395CCA4FA7B24ABC6049683E716292B00C49509BE147AA024C06286BD
+      9B7DBDA81601
    58 40                                # bytes(64)
-      AFE8658C6F5229951DB4DB82F62E9D930B6CD8F155C5D47586556012E
-      D9C560487C05AAE58A2B66970CBAB666E43890DEB01F33E5281B0F9C7
-      E22F68A437AF09
+      3A7F29F7395CC454C3904DE2236EEF2C0147496B77C556ADE1A08BF57
+      D3E70D2A43A4C723AEB5366D4F073CEEB8B2677E03EC62E49D1647C67
+      0D95CC77F9DB07
    56                                   # bytes(22)
       7B2269223A312C2274797065223A2274657374227D0A
-
 ~~~~~~~~~~~
-
 
 # Code and roll out
 

--- a/drafts/draft-ssb-core-gabbygrove/00/draft-ssb-core-gabbygrove-00.txt
+++ b/drafts/draft-ssb-core-gabbygrove/00/draft-ssb-core-gabbygrove-00.txt
@@ -4,8 +4,8 @@
 
 Secure Scuttlebutt Working Group                               . cryptix
 SSB-Draft                                                           SSBC
-Intended status: Informational                           August 16, 2019
-Expires: February 17, 2020
+Intended status: Informational                        September 09, 2019
+Expires: March 12, 2020
 
 
                   GabbyGrove (CBOR-based Feed Format)
@@ -33,7 +33,7 @@ Status of This Memo
    time.  It is inappropriate to use SSB-Drafts as reference material or
    to cite them other than as "work in progress."
 
-   This SSB-Draft will expire on February 17, 2020.
+   This SSB-Draft will expire on March 12, 2020.
 
 Copyright Notice
 
@@ -53,9 +53,9 @@ Table of Contents
 
 
 
-cryptix                 Expires February 17, 2020               [Page 1]
+cryptix                  Expires March 12, 2020                 [Page 1]
 
-SSB-Draft                   DRAFT GabbyGrove                 August 2019
+SSB-Draft                   DRAFT GabbyGrove              September 2019
 
 
      3.2.  Transfer  . . . . . . . . . . . . . . . . . . . . . . . .   4
@@ -75,7 +75,7 @@ SSB-Draft                   DRAFT GabbyGrove                 August 2019
      6.1.  Alternative Encodings . . . . . . . . . . . . . . . . . .  13
      6.2.  Deletion requests . . . . . . . . . . . . . . . . . . . .  13
      6.3.  Size benefits . . . . . . . . . . . . . . . . . . . . . .  13
-     6.4.  How long lived this will be?  . . . . . . . . . . . . . .  14
+     6.4.  How long lived this will be?  . . . . . . . . . . . . . .  13
    7.  Addressed comments from ProtoChain  . . . . . . . . . . . . .  14
      7.1.  Event . . . . . . . . . . . . . . . . . . . . . . . . . .  14
      7.2.  "Content Type"  . . . . . . . . . . . . . . . . . . . . .  14
@@ -83,7 +83,7 @@ SSB-Draft                   DRAFT GabbyGrove                 August 2019
        proposal  . . . . . . . . . . . . . . . . . . . . . . . . . .  14
      8.1.  incrementing on a broken format . . . . . . . . . . . . .  14
      8.2.  The use of MUXRPC specific features for
-           transmission/replication  . . . . . . . . . . . . . . . .  15
+           transmission/replication  . . . . . . . . . . . . . . . .  14
    9.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  15
      9.1.  Informative References  . . . . . . . . . . . . . . . . .  15
      9.2.  URIs  . . . . . . . . . . . . . . . . . . . . . . . . . .  15
@@ -109,9 +109,9 @@ SSB-Draft                   DRAFT GabbyGrove                 August 2019
 
 
 
-cryptix                 Expires February 17, 2020               [Page 2]
+cryptix                  Expires March 12, 2020                 [Page 2]
 
-SSB-Draft                   DRAFT GabbyGrove                 August 2019
+SSB-Draft                   DRAFT GabbyGrove              September 2019
 
 
 2.1.  Keeping the timestamp
@@ -165,9 +165,9 @@ SSB-Draft                   DRAFT GabbyGrove                 August 2019
 
 
 
-cryptix                 Expires February 17, 2020               [Page 3]
+cryptix                  Expires March 12, 2020                 [Page 3]
 
-SSB-Draft                   DRAFT GabbyGrove                 August 2019
+SSB-Draft                   DRAFT GabbyGrove              September 2019
 
 
    o  The "sequence" number of the entry as an unsigned integer.
@@ -221,9 +221,9 @@ SSB-Draft                   DRAFT GabbyGrove                 August 2019
 
 
 
-cryptix                 Expires February 17, 2020               [Page 4]
+cryptix                  Expires March 12, 2020                 [Page 4]
 
-SSB-Draft                   DRAFT GabbyGrove                 August 2019
+SSB-Draft                   DRAFT GabbyGrove              September 2019
 
 
    In this first version we don't plan to support many formats, which is
@@ -277,9 +277,9 @@ SSB-Draft                   DRAFT GabbyGrove                 August 2019
 
 
 
-cryptix                 Expires February 17, 2020               [Page 5]
+cryptix                  Expires March 12, 2020                 [Page 5]
 
-SSB-Draft                   DRAFT GabbyGrove                 August 2019
+SSB-Draft                   DRAFT GabbyGrove              September 2019
 
 
 3.4.  Signing capability
@@ -333,9 +333,9 @@ SSB-Draft                   DRAFT GabbyGrove                 August 2019
 
 
 
-cryptix                 Expires February 17, 2020               [Page 6]
+cryptix                  Expires March 12, 2020                 [Page 6]
 
-SSB-Draft                   DRAFT GabbyGrove                 August 2019
+SSB-Draft                   DRAFT GabbyGrove              September 2019
 
 
    A4               # map(4)
@@ -389,9 +389,9 @@ SSB-Draft                   DRAFT GabbyGrove                 August 2019
 
 
 
-cryptix                 Expires February 17, 2020               [Page 7]
+cryptix                  Expires March 12, 2020                 [Page 7]
 
-SSB-Draft                   DRAFT GabbyGrove                 August 2019
+SSB-Draft                   DRAFT GabbyGrove              September 2019
 
 
    the size overhead of encoding structures as maps can be mitigated by
@@ -445,9 +445,9 @@ SSB-Draft                   DRAFT GabbyGrove                 August 2019
 
 
 
-cryptix                 Expires February 17, 2020               [Page 8]
+cryptix                  Expires March 12, 2020                 [Page 8]
 
-SSB-Draft                   DRAFT GabbyGrove                 August 2019
+SSB-Draft                   DRAFT GabbyGrove              September 2019
 
 
    has to be checked in context of the feed for append validation, this
@@ -489,21 +489,21 @@ SSB-Draft                   DRAFT GabbyGrove                 August 2019
     6:         AED3DAB65CE9E0D6C50D46FCEFFB5522
     7:         96ED21B6E0B537A6A0184575CE8F5CBD
     8:   01                                   # unsigned(1)
-    9:   1A 5D3F8880                          # unsigned(1564444800)
+    9:   24                                   # negative(4)
    10:   83                                   # array(3)
-   11:      01                                # unsigned(1)
-   12:      07                                # unsigned(7)
-   13:      D9 041A                           # tag(1050)
-   14:         58 21                          # bytes(33)
-   15:            03
-   16:            E806ECF2B7C37FB06DC198A9B905BE64
-   17:            EE3FDB8237EF80D316ACB7C85BBF5F02
+   11:      D9 041A                           # tag(1050)
+   12:         58 21                          # bytes(33)
+   13:            03
+   14:            A7AC59B52AFF894BA89508B35F445AE9
+   15:            0628F6D5F358157E4F45F39B5B3BE96B
+   16:      09                                # unsigned(9)
+   17:      00                                # unsigned(0)
 
 
 
-cryptix                 Expires February 17, 2020               [Page 9]
+cryptix                  Expires March 12, 2020                 [Page 9]
 
-SSB-Draft                   DRAFT GabbyGrove                 August 2019
+SSB-Draft                   DRAFT GabbyGrove              September 2019
 
 
    Let's discuss line by line what this means:
@@ -540,37 +540,33 @@ SSB-Draft                   DRAFT GabbyGrove                 August 2019
    8.   The next line is the third element of the array: the "sequence"
         number encoded as an unsigned integer, as the comment tells us.
 
-   9.   The fourth element is the "timestamp" also encoded as an
-        unsigned integer.  As a starting timestamp I picked 2019-07-30,
-        which translates to 1564444800 seconds as a Unix epoch
-        timestamp.
+   9.   The fourth element is the "timestamp" encoded as an signed
+        integer.  As a starting timestamp I picked 1969-12-31 23:59:55,
+        which translates to -5 seconds as a UNIX epoch timestamp.
 
    10.  The fifth element is the "content" object, which itself is
-        encoded as an array of 3 items ("encoding", "size" and "hash")
+        encoded as an array of 3 items ("hash", "size" and "encoding")
 
-   11.  The number 1 means the content was encoded as "json" (See
-        Section 2.3).
+   11.  First, we have a cipherlink for the "hash".
 
-   12.  This is the content's "size", in bytes also as an unsigned
-        integer.  Meaning, this content is 7 bytes long.
-
-
-
-
-cryptix                 Expires February 17, 2020              [Page 10]
-
-SSB-Draft                   DRAFT GabbyGrove                 August 2019
-
-
-   13.  Finally, we have a cipherlink again.
-
-   14.  It's 33 bytes long
-
-   15.  It starts with 03 which means, it's a content hash.  (See
+   12.  It starts with 03 which means, it's a content hash.  (See
         Section 3.3)
 
-   16.  The following two lines are the hash function output.  Where
-        this comes from will be shown in the next section.
+   13.  The following two lines are the hash function output.  How to
+        compute these will be shown in the next section.
+
+
+
+cryptix                  Expires March 12, 2020                [Page 10]
+
+SSB-Draft                   DRAFT GabbyGrove              September 2019
+
+
+   14.  This is the content's "size", in bytes also as an unsigned
+        integer.  Meaning, this content is 9 bytes long.
+
+   15.  The number 0 means the content was encoded as "binary" (See
+        Section 2.3).
 
    Here is the next message:
 
@@ -578,31 +574,34 @@ SSB-Draft                   DRAFT GabbyGrove                 August 2019
       D9 041A                              # tag(1050)
          58 21                             # bytes(33)
             02
-            0113F4DD8C981D1D87BC7F46CF86E8E7
-            B0FB774F839930DD38D6A13F69D9693D
+            CCD8FD8392C1B9D1E3026DEA42BEC93E
+            04B6F8ECEB9AF2D591489EB8B831C5E1
       D9 041A                              # tag(1050)
          58 21                             # bytes(33)
             01
             AED3DAB65CE9E0D6C50D46FCEFFB5522
             96ED21B6E0B537A6A0184575CE8F5CBD
       02                                   # unsigned(2)
-      1A 5D3F8881                          # unsigned(1564444801)
+      23                                   # negative(3)
       83                                   # array(3)
-         01                                # unsigned(1)
-         16                                # unsigned(22)
          D9 041A                           # tag(1050)
             58 21                          # bytes(33)
                03
                95CCA4FA7B24ABC6049683E716292B00
                C49509BE147AA024C06286BD9B7DBDA8
+         16                                # unsigned(22)
+         01                                # unsigned(1)
 
 
    If you compare this to the above you should see some similarities.
    Instead of "0xf6" as the first element as the array we now have
-   "0xD0491A5821".  We have seen this sequence twice above already: It's
-   a cipherlink with 33 bytes of data.  Instead of starting with byte
-   "0x01" or "0x03", this starts with "0x02" which means, it's a hash of
-   a signed event.
+   "0xD9041A5821".  We have seen this sequence of bytes twice above
+   already: It's a cipherlink with 33 bytes of data.  Instead of
+   starting with byte "0x01" or "0x03", this starts with "0x02" which
+   means, it's a hash of a signed event.
+
+   The content type is "0x01" instead and the timestamp is advanced by 1
+   as well as the "sequence".
 
 4.4.3.  Transfer
 
@@ -613,23 +612,23 @@ SSB-Draft                   DRAFT GabbyGrove                 August 2019
 
 
 
-cryptix                 Expires February 17, 2020              [Page 11]
+
+cryptix                  Expires March 12, 2020                [Page 11]
 
-SSB-Draft                   DRAFT GabbyGrove                 August 2019
+SSB-Draft                   DRAFT GabbyGrove              September 2019
 
 
    83                                      # array(3)
-      58 57                                # bytes(87)
+      58 53                                # bytes(83)
          85F6D9041A582101AED3DAB65CE9E0D6C50D46FCEFFB552296ED21B6E
-         0B537A6A0184575CE8F5CBD011A5D3F8880830107D9041A582103E806
-         ECF2B7C37FB06DC198A9B905BE64EE3FDB8237EF80D316ACB7C85BBF5
-         F02
+         0B537A6A0184575CE8F5CBD012483D9041A582103A7AC59B52AFF894B
+         A89508B35F445AE90628F6D5F358157E4F45F39B5B3BE96B0900
       58 40                                # bytes(64)
-         91F1B00C37285FC517D4C87FDA951A6BC38AEE7E7DCB8E3CE538289C5
-         CBA0E93A5734BD6853D11FA29DDF0BFE5BC4B5049EF4681CAA1BAA355
-         CD2FFC94191104
-      47                                   # bytes(7)
-         666F6F2E626F78                    # "foo.box"
+         8A3739FDB99D91E28552E9A2E22650C14A8CDBFE607CDCA5767569DB2
+         B1E24CAA3C31D65964143DC752E568B05C99E0E97C198885BFB8F3549
+         B9C6CCBC991205
+      49                                   # bytes(9)
+         FF7330316D4279747A                # "\xFFs01mBytz"
 
    Similar to the above, we have an array with 3 elements, each in turn
    being a byte string of varying size.  The first one is the
@@ -641,19 +640,18 @@ SSB-Draft                   DRAFT GabbyGrove                 August 2019
    Here is the transfer object for the second event:
 
    83                                      # array(3)
-      58 7C                                # bytes(124)
-         85D9041A5821020113F4DD8C981D1D87BC7F46CF86E8E7B0FB774F839
-         930DD38D6A13F69D9693DD9041A582101AED3DAB65CE9E0D6C50D46FC
-         EFFB552296ED21B6E0B537A6A0184575CE8F5CBD021A5D3F888183011
-         6D9041A58210395CCA4FA7B24ABC6049683E716292B00C49509BE147A
-         A024C06286BD9B7DBDA8
+      58 78                                # bytes(120)
+         85D9041A582102CCD8FD8392C1B9D1E3026DEA42BEC93E04B6F8ECEB9
+         AF2D591489EB8B831C5E1D9041A582101AED3DAB65CE9E0D6C50D46FC
+         EFFB552296ED21B6E0B537A6A0184575CE8F5CBD022383D9041A58210
+         395CCA4FA7B24ABC6049683E716292B00C49509BE147AA024C06286BD
+         9B7DBDA81601
       58 40                                # bytes(64)
-         AFE8658C6F5229951DB4DB82F62E9D930B6CD8F155C5D47586556012E
-         D9C560487C05AAE58A2B66970CBAB666E43890DEB01F33E5281B0F9C7
-         E22F68A437AF09
+         3A7F29F7395CC454C3904DE2236EEF2C0147496B77C556ADE1A08BF57
+         D3E70D2A43A4C723AEB5366D4F073CEEB8B2677E03EC62E49D1647C67
+         0D95CC77F9DB07
       56                                   # bytes(22)
          7B2269223A312C2274797065223A2274657374227D0A
-
 
 5.  Code and roll out
 
@@ -666,16 +664,15 @@ SSB-Draft                   DRAFT GabbyGrove                 August 2019
    One open question would be how to get this into EBT while also
    supporting the classical/legacy way of encoding feeds.  For
    replication of single feeds we can use the established stream command
-
-
-
-cryptix                 Expires February 17, 2020              [Page 12]
-
-SSB-Draft                   DRAFT GabbyGrove                 August 2019
-
-
    "createHistoryStream" which can pick the correct transfer encoding
    based on the passed feed reference.
+
+
+
+cryptix                  Expires March 12, 2020                [Page 12]
+
+SSB-Draft                   DRAFT GabbyGrove              September 2019
+
 
 6.  Remarks
 
@@ -718,18 +715,6 @@ SSB-Draft                   DRAFT GabbyGrove                 August 2019
    Converting content to a binary encoding would reduce it further but
    as stated above would require strict schemas for every type.
 
-
-
-
-
-
-
-
-cryptix                 Expires February 17, 2020              [Page 13]
-
-SSB-Draft                   DRAFT GabbyGrove                 August 2019
-
-
 6.4.  How long lived this will be?
 
    I _think_ this is a solid format but wouldn't mind to be superseded
@@ -737,6 +722,14 @@ SSB-Draft                   DRAFT GabbyGrove                 August 2019
    we double down on "sameAs".  The _simplest_ case of it would be
    terminating one feed and starting a new one, while logically
    appending one to the other for higher levels of the protocol stack.
+
+
+
+cryptix                  Expires March 12, 2020                [Page 13]
+
+SSB-Draft                   DRAFT GabbyGrove              September 2019
+
+
    The implications for indexing things like the friend graph and how to
    end feeds in the old format show that this needs to be covered in a
    separate spec.
@@ -779,19 +772,19 @@ SSB-Draft                   DRAFT GabbyGrove                 August 2019
    formats_ in the stack.  Personally I think this is good though as it
    will pave the way for other formats, like bamboo, as well.
 
-
-
-cryptix                 Expires February 17, 2020              [Page 14]
-
-SSB-Draft                   DRAFT GabbyGrove                 August 2019
-
-
 8.2.  The use of MUXRPC specific features for transmission/replication
 
    The idea to transmit content and metadata as two MUXRPC [29] frames
    was my idea.  It seems sensible/practical because it fitted into the
    existing stack but I see now that it tried to much to fit into the
    existing way and hid a dependency along the way.
+
+
+
+cryptix                  Expires March 12, 2020                [Page 14]
+
+SSB-Draft                   DRAFT GabbyGrove              September 2019
+
 
    This is why the "transfer" structure definition has a dedicated field
    for "content" which can be set to "null" to indicate unavailability.
@@ -834,14 +827,6 @@ SSB-Draft                   DRAFT GabbyGrove                 August 2019
 
    [9] https://w3c-ccg.github.io/did-spec/
 
-
-
-
-cryptix                 Expires February 17, 2020              [Page 15]
-
-SSB-Draft                   DRAFT GabbyGrove                 August 2019
-
-
    [10] https://github.com/ssbc/ssb-keys#signobjkeys-hmac_key-obj
 
    [11] https://en.wikipedia.org/wiki/HMAC
@@ -849,6 +834,13 @@ SSB-Draft                   DRAFT GabbyGrove                 August 2019
    [12] https://nacl.cr.yp.to/auth.html
 
    [13] https://cbor.io
+
+
+
+cryptix                  Expires March 12, 2020                [Page 15]
+
+SSB-Draft                   DRAFT GabbyGrove              September 2019
+
 
    [14] https://github.com/cabo/cbor-diag
 
@@ -893,4 +885,12 @@ Author's Address
 
 
 
-cryptix                 Expires February 17, 2020              [Page 16]
+
+
+
+
+
+
+
+
+cryptix                  Expires March 12, 2020                [Page 16]


### PR DESCRIPTION
The ordering of the content fields was not in line with the definitions (1. hash, 2.size, 3. type).